### PR TITLE
feat: PEP440 version specifier candidate filtering (#29)

### DIFF
--- a/src/core/resolver.rs
+++ b/src/core/resolver.rs
@@ -54,19 +54,41 @@ pub async fn resolve(
             continue;
         }
 
-        // Fetch package info.
-        // PyPI versioned API (/{name}/{version}/json) only accepts exact versions.
-        // Range specifiers like ">=2,<4" or "~=3.1" must be fetched as latest (/json),
-        // then the constraint is enforced by the caller.
-        let fetch_version = version_constraint.as_deref().and_then(|v| {
-            let trimmed = v.trim_start_matches("==");
-            if trimmed.chars().next().is_some_and(|c| c.is_ascii_digit()) {
-                Some(trimmed)
-            } else {
-                None // range specifier → fetch latest
+        // Determine which version to fetch from PyPI:
+        //   1. Exact specifier (==x.y.z)  → fetch the versioned endpoint directly.
+        //   2. Range/inequality specifier  → enumerate all releases, select the
+        //      highest version that satisfies all constraints (PEP440), then fetch
+        //      that specific version.
+        //   3. No constraint               → fetch the latest release endpoint.
+        let fetch_version: Option<String> = match version_constraint.as_deref() {
+            None | Some("") => None,
+            Some(constraint_str) => {
+                // Try to interpret as a bare exact version like "1.2.3"
+                let trimmed = constraint_str.trim_start_matches("==");
+                if trimmed.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                    Some(trimmed.to_string())
+                } else {
+                    // Range / inequality specifier: find the best satisfying version.
+                    match VersionSpecifiers::from_str(constraint_str) {
+                        Ok(specifiers) => {
+                            let full = package::fetch_full_package_info(&name).await?;
+                            match package::select_best_candidate(&full.releases, &specifiers) {
+                                Some(best) => Some(best),
+                                None => {
+                                    return Err(format!(
+                                        "No version of '{name}' satisfies constraint '{constraint_str}'"
+                                    )
+                                    .into())
+                                }
+                            }
+                        }
+                        Err(_) => None, // malformed specifier → fall back to latest
+                    }
+                }
             }
-        });
-        let info = package::fetch_package_info(&name, fetch_version).await?;
+        };
+
+        let info = package::fetch_package_info(&name, fetch_version.as_deref()).await?;
         // The info object is consumed directly below
         let mut sub_deps = Vec::new();
 

--- a/src/dependencies/package.rs
+++ b/src/dependencies/package.rs
@@ -1,8 +1,11 @@
 use flate2::read::GzDecoder;
+use pep508_rs::pep440_rs::{Version, VersionSpecifiers};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::Path;
+use std::str::FromStr;
 use tar::Archive;
 use zip::ZipArchive;
 
@@ -67,6 +70,29 @@ pub async fn fetch_full_package_info(name: &str) -> Result<PypiFullInfo, crate::
     } else {
         Err(format!("Could not find package {name} on PyPI").into())
     }
+}
+
+/// Selects the best (highest) version from a `PyPI` releases map that satisfies
+/// all provided PEP440 `specifiers`. Pre-release versions are skipped unless
+/// no stable version satisfies the constraints.
+///
+/// Returns `None` if no release satisfies the specifiers.
+pub fn select_best_candidate<S: ::std::hash::BuildHasher>(
+    releases: &HashMap<String, Vec<PackageUrl>, S>,
+    specifiers: &VersionSpecifiers,
+) -> Option<String> {
+    let candidates: Vec<Version> = releases
+        .keys()
+        .filter_map(|k| Version::from_str(k).ok())
+        .filter(|v| specifiers.contains(v))
+        .collect();
+
+    // Prefer stable over pre-release; fall back to pre-release only if nothing stable.
+    let stable: Vec<Version> = candidates.iter().filter(|v| !v.any_prerelease()).cloned().collect();
+
+    let pool = if stable.is_empty() { &candidates } else { &stable };
+
+    pool.iter().max().map(Version::to_string)
 }
 
 pub async fn download_package(url: &str, dest_path: &Path) -> Result<(), crate::core::error::WovenError> {

--- a/tests/unit/models.rs
+++ b/tests/unit/models.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use wovensnake::core::config::Config;
 use wovensnake::core::lock::Artifact;
 use wovensnake::core::selection::select_artifact;
+use wovensnake::dependencies::package::{select_best_candidate, Digests, PackageUrl};
 
 #[test]
 fn test_config_model() {
@@ -99,4 +100,76 @@ fn test_select_artifact_linux_aarch64_no_fallback_to_x86_64_when_no_any() {
         result.is_none(),
         "should not select an incompatible x86_64 wheel on aarch64"
     );
+}
+
+// ── PEP440 candidate-selection unit tests ────────────────────────────────────
+
+/// Build a synthetic releases map from a list of version strings.
+/// URLs are empty because select_best_candidate only examines the map keys.
+fn make_releases(versions: &[&str]) -> HashMap<String, Vec<wovensnake::dependencies::package::PackageUrl>> {
+    use wovensnake::dependencies::package::{Digests, PackageUrl};
+    versions
+        .iter()
+        .map(|v| {
+            let url = PackageUrl {
+                url: format!("https://files.example.com/{v}.whl"),
+                filename: format!("{v}.whl"),
+                packagetype: "bdist_wheel".to_string(),
+                digests: Digests {
+                    sha256: "deadbeef".to_string(),
+                },
+            };
+            (v.to_string(), vec![url])
+        })
+        .collect()
+}
+
+#[test]
+fn test_pep440_exact() {
+    use std::str::FromStr;
+    let releases = make_releases(&["1.2.2", "1.2.3", "1.3.0"]);
+    let specs = pep508_rs::pep440_rs::VersionSpecifiers::from_str("==1.2.3").unwrap();
+    assert_eq!(select_best_candidate(&releases, &specs).as_deref(), Some("1.2.3"));
+}
+
+#[test]
+fn test_pep440_range() {
+    use std::str::FromStr;
+    let releases = make_releases(&["0.9", "1.0", "1.5", "2.0"]);
+    let specs = pep508_rs::pep440_rs::VersionSpecifiers::from_str(">=1.0,<2.0").unwrap();
+    assert_eq!(select_best_candidate(&releases, &specs).as_deref(), Some("1.5"));
+}
+
+#[test]
+fn test_pep440_tilde_equal() {
+    use std::str::FromStr;
+    // ~=1.4 means >=1.4, <2.0
+    let releases = make_releases(&["1.3", "1.4", "1.5", "2.0"]);
+    let specs = pep508_rs::pep440_rs::VersionSpecifiers::from_str("~=1.4").unwrap();
+    assert_eq!(select_best_candidate(&releases, &specs).as_deref(), Some("1.5"));
+}
+
+#[test]
+fn test_pep440_not_equal() {
+    use std::str::FromStr;
+    let releases = make_releases(&["1.0", "1.4", "1.5", "1.6"]);
+    let specs = pep508_rs::pep440_rs::VersionSpecifiers::from_str("!=1.5,>=1.0").unwrap();
+    assert_eq!(select_best_candidate(&releases, &specs).as_deref(), Some("1.6"));
+}
+
+#[test]
+fn test_pep440_no_match_returns_none() {
+    use std::str::FromStr;
+    let releases = make_releases(&["1.0", "2.0"]);
+    let specs = pep508_rs::pep440_rs::VersionSpecifiers::from_str(">=99.0").unwrap();
+    assert!(select_best_candidate(&releases, &specs).is_none());
+}
+
+#[test]
+fn test_pep440_prerelease_skipped_when_stable_exists() {
+    use std::str::FromStr;
+    let releases = make_releases(&["1.0", "2.0a1"]);
+    let specs = pep508_rs::pep440_rs::VersionSpecifiers::from_str(">=1.0").unwrap();
+    // 2.0a1 satisfies >=1.0 but is pre-release; 1.0 is stable and should win.
+    assert_eq!(select_best_candidate(&releases, &specs).as_deref(), Some("1.0"));
 }


### PR DESCRIPTION
## Summary

Closes #29

The resolver was fetching the **latest** PyPI version for any range specifier (`>=1.0,<2.0`, `~=3.1`, `!=2.0`), ignoring the actual constraint. This PR fixes that with proper PEP440 candidate selection.

## Changes

### `src/dependencies/package.rs`
- Added `select_best_candidate<S: BuildHasher>()`: enumerates all versions from the PyPI releases map, filters with `pep440_rs::VersionSpecifiers`, prefers stable over pre-release versions, and returns the highest compatible version.

### `src/core/resolver.rs`
- Replaced the naive fetch-latest logic with a **3-path approach**:
  1. **Exact** (`==x.y.z`) → fetch the versioned endpoint directly
  2. **Range/inequality** → fetch all releases via `fetch_full_package_info`, run `select_best_candidate`, then fetch that exact version (for `requires_dist` + URLs)
  3. **No constraint** → fetch latest (unchanged)
- Returns a descriptive error if no version satisfies the constraint.

### `tests/unit/models.rs`
- 6 new unit tests (no network): `==`, `>=/<`, `~=`, `!=`, no-match, pre-release skip

## Test Results

```
test result: ok. 13 passed; 0 failed; 0 ignored
```

## Checklist
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo test` — 13/13 passing